### PR TITLE
Add --detach-path-deps

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -17,6 +17,7 @@ build.allow-build-scripts = [
     { name = "anyhow" },
     { name = "libc" },                         # via ctrlc & is-terminal
     { name = "rustix" },                       # via is-terminal
+    { name = "semver" },
     { name = "serde_json" },
     { name = "serde" },
     { name = "winapi-i686-pc-windows-gnu" },   # via same-file & termcolor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `--detach-path-deps` flag to run minimal versions check with `path` fields removed from dependencies. ([#4](https://github.com/taiki-e/cargo-minimal-versions/pull/4))
+
 ## [0.1.19] - 2023-09-11
 
 - Remove dependency on `slab`, `shell-escape`, and `fs-err`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ ctrlc = { version = "3.1.4", features = ["termination"] }
 is-terminal = "0.4"
 lexopt = "0.3"
 same-file = "1.0.1"
+semver = "1"
 serde_json = "1"
 termcolor = "1"
 toml_edit = "0.20"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ Normally, crates with `publish = false` do not need minimal versions check. You 
 cargo minimal-versions check --workspace --ignore-private
 ```
 
+If path dependencies exist, the above ways may miss the problem when you publish the crate (e.g., [tokio-rs/tokio#4376], [tokio-rs/tokio#4490]) <br>
+By using `--detach-path-deps` flag, you can run minimal versions check with `path` fields removed from dependencies.
+
+```sh
+cargo minimal-versions check --workspace --ignore-private --detach-path-deps
+```
+
+`--detach-path-deps` flag removes all[^1] path fields by default.
+By using `--detach-path-deps=skip-exact` flag, you can skip the removal of path fields in dependencies with exact version requirements (`"=<version>"`). For example, this is useful for [a pair of a proc-macro and a library that export it](https://github.com/taiki-e/pin-project/blob/df5ed4369e2c34d2111b71ef2fdd6b3621c55fa3/Cargo.toml#L32).
+
+[^1]: To exactly, when neither version, git, nor path is specified, an error will occur, so we will remove the path field of all of dependencies for which the version or git URL is specified.
+
 ## Details
 
 Using `-Z minimal-versions` in the usual way will not work properly in many cases. [To use `cargo check` with `-Z minimal-versions` properly, you need to run at least three processes.](https://github.com/tokio-rs/tokio/pull/3131#discussion_r521621961)
@@ -157,6 +169,8 @@ cargo binstall cargo-minimal-versions
 [cargo-hack]: https://github.com/taiki-e/cargo-hack
 [cargo-llvm-cov]: https://github.com/taiki-e/cargo-llvm-cov
 [cargo#5657]: https://github.com/rust-lang/cargo/issues/5657
+[tokio-rs/tokio#4376]: https://github.com/tokio-rs/tokio/pull/4376
+[tokio-rs/tokio#4490]: https://github.com/tokio-rs/tokio/pull/4490
 
 ## License
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,9 +50,7 @@ fn try_main() -> Result<()> {
                 a.starts_with("--example=") || a.starts_with("--test=") || a.starts_with("--bench=")
             }
         });
-    // TODO: provide option to keep updated Cargo.lock
-    let restore_lockfile = true;
-    manifest::with(&ws.metadata, remove_dev_deps, args.no_private, restore_lockfile, || {
+    manifest::with(&ws.metadata, &args, remove_dev_deps, || {
         // Update Cargo.lock to minimal version dependencies.
         let mut cargo = ws.cargo_nightly();
         cargo.args(["update", "-Z", "minimal-versions"]);
@@ -62,10 +60,10 @@ fn try_main() -> Result<()> {
         let mut cargo = ws.cargo();
         // TODO: Provide a way to do this without using cargo-hack.
         cargo.arg("hack");
-        cargo.args(args.cargo_args);
+        cargo.args(&args.cargo_args);
         if !args.rest.is_empty() {
             cargo.arg("--");
-            cargo.args(args.rest);
+            cargo.args(&args.rest);
         }
         info!("running {cargo}");
         cargo.run()


### PR DESCRIPTION
If path dependencies exist, the above ways may miss the problem when you publish the crate (e.g., tokio-rs/tokio#4376, tokio-rs/tokio#4490)
By using `--detach-path-deps` flag, you can run minimal versions check with `path` fields removed from dependencies.

```sh
cargo minimal-versions check --workspace --ignore-private --detach-path-deps
```

`--detach-path-deps` (`--detach-path-deps=all`) flag removes all[^1] path fields by default.
By using `--detach-path-deps=skip-exact` flag, you can skip the removal of path fields in dependencies with exact version requirements (`"=<version>"`). For example, this is useful for [a pair of a proc-macro and a library that export it](https://github.com/taiki-e/pin-project/blob/df5ed4369e2c34d2111b71ef2fdd6b3621c55fa3/Cargo.toml#L32).

### Open questions:

- Is `--detach-path-deps=all` a reasonable default?
- Should this be enabled by default?

[^1]: To exactly, when neither version, git, nor path is specified, an error will occur, so we will remove the path field of all of dependencies for which the version or git URL is specified.


~~This also fixes \ #1 (the 3rd commit)~~ EDIT: see https://github.com/taiki-e/cargo-minimal-versions/pull/4#issuecomment-1766827197