### PR TITLE
Add --direct flag to use -Z direct-minimal-versions instead of -Z minimal-versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
       - run: cargo install -f --path . --debug
       - run: cargo minimal-versions check --workspace --no-private --detach-path-deps=skip-exact --all-features -v
       - run: cargo minimal-versions build --workspace --no-private --detach-path-deps=skip-exact --all-features -v
+      - run: cargo minimal-versions build --workspace --no-private --detach-path-deps=skip-exact --all-features -v --direct
       - run: cargo minimal-versions test --workspace --all-features -v
       - run: |
           set -eEuxo pipefail
@@ -81,6 +82,7 @@ jobs:
           cd portable-atomic
           rustup toolchain add 1.34 --no-self-update
           RUSTC_BOOTSTRAP=1 cargo +1.34 minimal-versions build --workspace --no-private -v
+          RUSTC_BOOTSTRAP=1 cargo +1.34 minimal-versions build --workspace --no-private --detach-path-deps=all -v
         if: startsWith(matrix.rust, 'nightly')
 
   test-no-rustup:
@@ -102,6 +104,7 @@ jobs:
       - run: cargo install -f --path . --debug
       - run: cargo minimal-versions check --workspace --no-private --detach-path-deps=skip-exact --all-features -v
       - run: cargo minimal-versions build --workspace --no-private --detach-path-deps=skip-exact --all-features -v
+      - run: cargo minimal-versions build --workspace --no-private --detach-path-deps=skip-exact --all-features -v --direct
       - run: cargo minimal-versions test --workspace --all-features -v
 
   miri:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `--direct` flag to use [`-Z direct-minimal-versions`](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#direct-minimal-versions) instead of `-Z minimal-versions`. ([#25](https://github.com/taiki-e/cargo-minimal-versions/pull/25))
+
 ## [0.1.20] - 2023-10-22
 
 - Add `--detach-path-deps` flag to run minimal versions check with `path` fields removed from dependencies. ([#4](https://github.com/taiki-e/cargo-minimal-versions/pull/4))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["cargo", "subcommand", "testing"]
 categories = ["command-line-utilities", "development-tools::cargo-plugins", "development-tools::testing"]
 exclude = ["/.*", "/tools"]
 description = """
-Cargo subcommand for proper use of -Z minimal-versions.
+Cargo subcommand for proper use of -Z minimal-versions and -Z direct-minimal-versions.
 """
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![license](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue?style=flat-square)](#license)
 [![build status](https://img.shields.io/github/actions/workflow/status/taiki-e/cargo-minimal-versions/ci.yml?branch=main&style=flat-square&logo=github)](https://github.com/taiki-e/cargo-minimal-versions/actions)
 
-Cargo subcommand for proper use of [`-Z minimal-versions`][cargo#5657].
+Cargo subcommand for proper use of [`-Z minimal-versions`][cargo#5657] and [`-Z direct-minimal-versions`][direct-minimal-versions].
 
 - [Usage](#usage)
 - [Details](#details)
@@ -22,7 +22,7 @@ Cargo subcommand for proper use of [`-Z minimal-versions`][cargo#5657].
 $ cargo minimal-versions --help
 cargo-minimal-versions
 
-Cargo subcommand for proper use of -Z minimal-versions.
+Cargo subcommand for proper use of -Z minimal-versions and -Z direct-minimal-versions.
 
 USAGE:
     cargo minimal-versions <CARGO_SUBCOMMAND> [OPTIONS] [CARGO_OPTIONS]
@@ -63,6 +63,18 @@ By using `--detach-path-deps=skip-exact` flag, you can skip the removal of path 
 
 [^1]: To exactly, when neither version, git, nor path is specified, an error will occur, so we will remove the path field of all of dependencies for which the version or git URL is specified.
 
+### --direct (-Z direct-minimal-versions)
+
+If there are dependencies that are incompatible with `-Z minimum-versions`, it is also reasonable to use [`-Z direct-minimal-versions`][direct-minimal-versions], since it is hard to maintain `-Z minimum-versions` compatibility in such situations.
+
+By using `--direct` flag, cargo-minimal-versions uses `-Z direct-minimal-versions` instead of `-Z minimal-versions`.
+
+```sh
+cargo minimal-versions check --direct
+```
+
+Note that using `-Z direct-minimal-versions` may miss some of the problems that can be found when using `-Z minimal-versions`. However, if there is a problem only in a particular version of a dependency, a problem that was missed when using `-Z minimal-versions` may be found by using `-Z direct-minimal-versions` (because the resolved dependency version is different).
+
 ## Details
 
 Using `-Z minimal-versions` in the usual way will not work properly in many cases. [To use `cargo check` with `-Z minimal-versions` properly, you need to run at least three processes.](https://github.com/tokio-rs/tokio/pull/3131#discussion_r521621961)
@@ -83,7 +95,7 @@ See [#1](https://github.com/taiki-e/cargo-minimal-versions/issues/1) and [#6](ht
 ### Prerequisites
 
 cargo-minimal-versions requires nightly
-toolchain (to run `cargo update -Z minimal-versions`) and [cargo-hack] (to run `cargo check` & `cargo build` proper):
+toolchain (to run `cargo update -Z minimal-versions` or `cargo update -Z direct-minimal-versions`) and [cargo-hack] (to run `cargo check` & `cargo build` proper):
 
 ```sh
 rustup toolchain add nightly
@@ -169,6 +181,7 @@ cargo binstall cargo-minimal-versions
 [cargo-hack]: https://github.com/taiki-e/cargo-hack
 [cargo-llvm-cov]: https://github.com/taiki-e/cargo-llvm-cov
 [cargo#5657]: https://github.com/rust-lang/cargo/issues/5657
+[direct-minimal-versions]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#direct-minimal-versions
 [tokio-rs/tokio#4376]: https://github.com/tokio-rs/tokio/pull/4376
 [tokio-rs/tokio#4490]: https://github.com/tokio-rs/tokio/pull/4490
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@ use lexopt::{
 use crate::term;
 
 static USAGE: &str = "cargo-minimal-versions\n
-Cargo subcommand for proper use of -Z minimal-versions.
+Cargo subcommand for proper use of -Z minimal-versions and -Z direct-minimal-versions.
 \nUSAGE:
     cargo minimal-versions <CARGO_SUBCOMMAND> [OPTIONS] [CARGO_OPTIONS]
 \nCARGO_SUBCOMMANDS:
@@ -23,6 +23,7 @@ Cargo subcommand for proper use of -Z minimal-versions.
 
 pub(crate) struct Args {
     pub(crate) no_private: bool,
+    pub(crate) direct: bool,
     pub(crate) subcommand: Subcommand,
     pub(crate) manifest_path: Option<String>,
     pub(crate) detach_path_deps: Option<DetachPathDeps>,
@@ -108,6 +109,7 @@ impl Args {
         let mut verbose = 0;
         let mut detach_path_deps = None;
 
+        let mut direct = false;
         let mut no_private = false;
 
         let mut parser = lexopt::Parser::from_args(args);
@@ -147,6 +149,8 @@ impl Args {
                         detach_path_deps = Some(DetachPathDeps::All);
                     }
                 }
+
+                Long("direct") => parse_flag!(direct),
 
                 // cargo-hack flags
                 // However, do not propagate to cargo-hack, as the same process
@@ -212,7 +216,15 @@ impl Args {
             cargo_args.push(path.clone());
         }
 
-        Ok(Self { no_private, subcommand, manifest_path, detach_path_deps, cargo_args, rest })
+        Ok(Self {
+            no_private,
+            direct,
+            subcommand,
+            manifest_path,
+            detach_path_deps,
+            cargo_args,
+            rest,
+        })
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,11 @@ fn try_main() -> Result<()> {
     manifest::with(&ws.metadata, &args, remove_dev_deps, || {
         // Update Cargo.lock to minimal version dependencies.
         let mut cargo = ws.cargo_nightly();
-        cargo.args(["update", "-Z", "minimal-versions"]);
+        if args.direct {
+            cargo.args(["update", "-Z", "direct-minimal-versions"]);
+        } else {
+            cargo.args(["update", "-Z", "minimal-versions"]);
+        }
         info!("running {cargo}");
         cargo.run()?;
 


### PR DESCRIPTION
If there are dependencies that are incompatible with `-Z minimum-versions`, it is also reasonable to use [`-Z direct-minimal-versions`][direct-minimal-versions], since it is hard to maintain `-Z minimum-versions` compatibility in such situations.

By using `--direct` flag, cargo-minimal-versions uses `-Z direct-minimal-versions` instead of `-Z minimal-versions`.

```sh
cargo minimal-versions check --direct
```

Note that using `-Z direct-minimal-versions` may miss some of the problems that can be found when using `-Z minimal-versions`. However, if there is a problem only in a particular version of a dependency, a problem that was missed when using `-Z minimal-versions` may be found by using `-Z direct-minimal-versions` (because the resolved dependency version is different).

Closes #16
cc https://github.com/rust-lang/cargo/issues/5657

[direct-minimal-versions]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#direct-minimal-versions
